### PR TITLE
Fix URL for Assets

### DIFF
--- a/importDialog.py
+++ b/importDialog.py
@@ -140,7 +140,7 @@ def main(gui, minecraftFolder):
     ids = []
     langJson, langJsonInverted = lang.getLang("lang/en_us.json")
     spritesheet = open("spritesheet.png", "wb")
-    spritesheet.write(urlopen("https://minecraft.gamepedia.com" + urlopen("https://minecraft.gamepedia.com/Template:InvSprite").read().decode().split("background-image:url(")[1].split(")")[0]).read())
+    spritesheet.write(urlopen(urlopen("https://minecraft.gamepedia.com/Template:InvSprite").read().decode().split("background-image:url(")[1].split(")")[0]).read())
     spritesheet.close()
     progress(window, layout, 310)
     rawLua = urlopen("https://minecraft.gamepedia.com/Module:InvSprite").read().decode().replace("&quot;", "'").split("ids = {\n")[1].split("</pre>")[0].split("\n")


### PR DESCRIPTION
Was going to use this tool but it errored on getting sprite data. Turns out, the minecraft wiki changed URLs (not a problem), but also changed from relativistic paths for the sprite data to absolute ones. This simply fixes that issue.

Another issue is that for some god forsaken reason, https://minecraft.fandom.com/wiki/Module:InvSprite does NOT have an entry for prismarine specifically, causing the application (in GUI mode) to crash if something like e.g. prismarine walls appears in a schematic, but i have no idea how i'd fix that in a non-jank way.

Else it seems to work great, thanks for making it.